### PR TITLE
Support LazyFrame

### DIFF
--- a/example/extend_polars/Cargo.toml
+++ b/example/extend_polars/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.18", features = ["extension-module"] }
-pyo3-polars = { version = "*", path = "../../pyo3-polars" }
+pyo3-polars = { version = "*", path = "../../pyo3-polars", features = ["lazy"] }
 polars-core = { version = "0.29" }
 polars-lazy =  "*"
 polars = { version = "*", features = ["fmt"] }

--- a/example/extend_polars/Cargo.toml
+++ b/example/extend_polars/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.18", features = ["extension-module"] }
 pyo3-polars = { version = "*", path = "../../pyo3-polars" }
 polars-core = { version = "0.29" }
+polars-lazy =  "*"
 polars = { version = "*", features = ["fmt"] }
 rayon = "1.6"

--- a/example/extend_polars/src/lib.rs
+++ b/example/extend_polars/src/lib.rs
@@ -2,10 +2,13 @@ mod parallel_jaccard_mod;
 
 use pyo3::prelude::*;
 use pyo3_polars::{
-    PyDataFrame
+    PyDataFrame,
+    PyLazyFrame,
 };
 use pyo3_polars::error::PyPolarsErr;
 use polars::prelude::*;
+use polars_lazy::frame::IntoLazy;
+use polars_lazy::prelude::LazyFrame;
 
 
 #[pyfunction]
@@ -15,9 +18,17 @@ fn parallel_jaccard(pydf: PyDataFrame, col_a: &str, col_b: &str) -> PyResult<PyD
     Ok(PyDataFrame(df))
 }
 
+#[pyfunction]
+fn lazy_parallel_jaccard(pydf: PyLazyFrame, col_a: &str, col_b: &str) -> PyResult<PyLazyFrame> {
+    let df: LazyFrame = pydf.into();
+    let df = parallel_jaccard_mod::parallel_jaccard(df.collect().unwrap(), col_a, col_b).map_err(PyPolarsErr::from)?;
+    Ok(PyLazyFrame(df.lazy()))
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn extend_polars(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parallel_jaccard, m)?)?;
+    m.add_function(wrap_pyfunction!(lazy_parallel_jaccard, m)?)?;
     Ok(())
 }

--- a/example/run.py
+++ b/example/run.py
@@ -1,5 +1,5 @@
 import polars as pl
-from extend_polars import parallel_jaccard
+from extend_polars import parallel_jaccard, lazy_parallel_jaccard
 
 df = pl.DataFrame({
     "list_a": [[1, 2, 3], [5, 5]],
@@ -8,3 +8,4 @@ df = pl.DataFrame({
 
 print(df)
 print(parallel_jaccard(df, "list_a", "list_b"))
+print(lazy_parallel_jaccard(df.lazy(), "list_a", "list_b").collect())

--- a/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/Cargo.toml
@@ -10,11 +10,15 @@ description = "PyO3 bindings to polars"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-polars = { version = "0.29.0", default_features = false, features=["serde-lazy"] }
-polars-core = { version = "0.29.0", default_features = false}
-polars-plan = { version = "0.29.0", default_features = false}
-polars-lazy = { version = "0.29.0", default_features = false }
+polars = { version = "0.29.0", default_features = false }
+polars-core = { version = "0.29.0", default_features = false }
+polars-plan = { version = "0.29.0", default_features = false, optional = true }
+polars-lazy = { version = "0.29.0", default_features = false, optional = true }
 pyo3 = "0.18.1"
 thiserror = "1"
 arrow2 = "0.17"
-ciborium = "0.2.0"
+ciborium = { version = "0.2.0", optional = true }
+
+[features]
+lazy = ["polars/serde-lazy", "polars-plan", "polars-lazy", "ciborium"]
+

--- a/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/Cargo.toml
@@ -10,8 +10,11 @@ description = "PyO3 bindings to polars"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-polars = { version = "0.29.0", default_features = false }
-polars-core = { version = "0.29.0", default_features = false }
+polars = { version = "0.29.0", default_features = false, features=["serde-lazy"] }
+polars-core = { version = "0.29.0", default_features = false}
+polars-plan = { version = "0.29.0", default_features = false}
+polars-lazy = { version = "0.29.0", default_features = false }
 pyo3 = "0.18.1"
 thiserror = "1"
 arrow2 = "0.17"
+ciborium = "0.2.0"

--- a/pyo3-polars/src/lib.rs
+++ b/pyo3-polars/src/lib.rs
@@ -43,9 +43,13 @@ mod ffi;
 use crate::error::PyPolarsErr;
 use crate::ffi::to_py::to_py_array;
 use polars::prelude::*;
-use polars_lazy::frame::LazyFrame;
-use polars_plan::logical_plan::LogicalPlan;
 use pyo3::{FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
+
+#[cfg(feature="lazy")]
+use {
+    polars_lazy::frame::LazyFrame,
+    polars_plan::logical_plan::LogicalPlan,
+};
 
 #[repr(transparent)]
 #[derive(Debug, Clone)]
@@ -57,6 +61,7 @@ pub struct PySeries(pub Series);
 /// A wrapper around a [`DataFrame`] that can be converted to and from python with `pyo3`.
 pub struct PyDataFrame(pub DataFrame);
 
+#[cfg(feature="lazy")]
 #[repr(transparent)]
 #[derive(Clone)]
 /// A wrapper around a [`DataFrame`] that can be converted to and from python with `pyo3`.
@@ -74,6 +79,7 @@ impl From<PySeries> for Series {
     }
 }
 
+#[cfg(feature="lazy")]
 impl From<PyLazyFrame> for LazyFrame {
     fn from(value: PyLazyFrame) -> Self {
         value.0
@@ -92,6 +98,7 @@ impl AsRef<DataFrame> for PyDataFrame {
     }
 }
 
+#[cfg(feature="lazy")]
 impl AsRef<LazyFrame> for PyLazyFrame {
     fn as_ref(&self) -> &LazyFrame {
         &self.0
@@ -126,6 +133,8 @@ impl<'a> FromPyObject<'a> for PyDataFrame {
         Ok(PyDataFrame(DataFrame::new_no_checks(columns)))
     }
 }
+
+#[cfg(feature="lazy")]
 impl<'a> FromPyObject<'a> for PyLazyFrame {
     fn extract(ob: &'a PyAny) -> PyResult<Self> {
         let s = ob.call_method0("__getstate__")?.extract::<Vec<u8>>()?;
@@ -168,6 +177,7 @@ impl IntoPy<PyObject> for PyDataFrame {
     }
 }
 
+#[cfg(feature="lazy")]
 impl IntoPy<PyObject> for PyLazyFrame {
     fn into_py(self, py: Python<'_>) -> PyObject {
         let polars = py.import("polars").expect("polars not installed");


### PR DESCRIPTION
This uses the cirobium ser/de of the logical plan to pass between python and
rust. In particular, it copies if the lazyframe contains a dataframe.

(Should I expect this serialization to be roughly stable between polars
versions? So that the python and rust versions can be slightly mismatched and
still work)

This pulls in quite a few extra dependencies, and I'm happy to put them behind
feature flags if desired.

Closes #9 