### PR TITLE
update example to polars 0.30.0

### DIFF
--- a/example/extend_polars/Cargo.toml
+++ b/example/extend_polars/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.18", features = ["extension-module"] }
 pyo3-polars = { version = "*", path = "../../pyo3-polars", features = ["lazy"] }
-polars-core = { version = "0.29" }
+polars-core = { version = "0.30" }
 polars-lazy =  "*"
 polars = { version = "*", features = ["fmt"] }
 rayon = "1.6"


### PR DESCRIPTION
error[E0271]: type mismatch resolving `<Vec<DataFrame> as IntoIterator>::Item == DataFrame`
   --> src/parallel_jaccard_mod.rs:67:36
    |
67  |     accumulate_dataframes_vertical(dfs)
    |     ------------------------------ ^^^ expected `DataFrame`, found `polars::prelude::DataFrame`
    |     |
    |     required by a bound introduced by this call
    |
    = note: `polars::prelude::DataFrame` and `DataFrame` have similar names, but are actually distinct types
note: `polars::prelude::DataFrame` is defined in crate `polars_core`
   --> /home/kan/.cargo/registry/src/github.com-1ecc6299db9ec823/polars-core-0.30.0/src/frame/mod.rs:142:1
    |
142 | pub struct DataFrame {
    | ^^^^^^^^^^^^^^^^^^^^
note: `DataFrame` is defined in crate `polars_core`
   --> /home/kan/.cargo/registry/src/github.com-1ecc6299db9ec823/polars-core-0.29.0/src/frame/mod.rs:143:1
    |
143 | pub struct DataFrame {
    | ^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `polars_core` are being used?
note: required by a bound in `accumulate_dataframes_vertical`
   --> /home/kan/.cargo/registry/src/github.com-1ecc6299db9ec823/polars-core-0.29.0/src/utils/mod.rs:556:21
    |
556 |     I: IntoIterator<Item = DataFrame>,
    |                     ^^^^^^^^^^^^^^^^ required by this bound in `accumulate_dataframes_vertical`