### PR TITLE
fix: add `polars` to `requirements.txt` for `derive_expression` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ out = df.with_columns(
 )
 ```
 
-See the full example in [example/derive_expression]: https://github.com/pola-rs/pyo3-polars/tree/plugin/example/derive_expression
+See the full example in [example/derive_expression]: https://github.com/pola-rs/pyo3-polars/tree/main/example/derive_expression
 
 ## 2. Pyo3 extensions for Polars
 

--- a/example/derive_expression/Makefile
+++ b/example/derive_expression/Makefile
@@ -15,7 +15,7 @@ install-release: venv
 
 clean:
 	-@rm -r venv
-	-@cd experssion_lib && cargo clean
+	-@cd expression_lib && cargo clean
 
 
 run: install

--- a/example/derive_expression/requirements.txt
+++ b/example/derive_expression/requirements.txt
@@ -1,1 +1,2 @@
 maturin
+polars[pyarrow]


### PR DESCRIPTION
I was just experimenting with the new Plugins API example and needed to make a few edits.

`make run` was failing as `polars` was missing from `requirements.txt` so wasn't being installed into the `venv`

`make clean` failed due to a typo in the directory name.

The URL for the derive_example in the README.md needed the branch name adjusted. (currently 404)