### PR TITLE
Remove pyarrow from `derive_expression` requirements

### DIFF
--- a/example/derive_expression/requirements.txt
+++ b/example/derive_expression/requirements.txt
@@ -1,2 +1,2 @@
 maturin
-polars[pyarrow]
+polars


### PR DESCRIPTION
Is pyarrow necessary here?

At least, I don't have it installed, but I got this running fine (I think?)

```python
(.venv) marcogorelli@DESKTOP-U8OKFP3:~/py03-polars-dev/example/derive_expression$ python -c 'import pyarrow'
Traceback (most recent call last):P3:~/py03-polars-dev/example/derive_expression$
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'pyarrow'
(.venv) marcogorelli@DESKTOP-U8OKFP3:~/py03-polars-dev/example/derive_expression$ python run.py
shape: (3, 9)
┌─────────┬───────┬─────────────┬───────────────┬───┬───────────┬──────────────┬─────────────┬───────────┐
│ names   ┆ moons ┆ dist_a      ┆ dist_b        ┆ … ┆ pig_latin ┆ hamming_dist ┆ jaccard_sim ┆ haversine │
│ ---     ┆ ---   ┆ ---         ┆ ---           ┆   ┆ ---       ┆ ---          ┆ ---         ┆ ---       │
│ str     ┆ str   ┆ list[i64]   ┆ list[i64]     ┆   ┆ str       ┆ u32          ┆ f64         ┆ f64       │
╞═════════╪═══════╪═════════════╪═══════════════╪═══╪═══════════╪══════════════╪═════════════╪═══════════╡
│ Richard ┆ full  ┆ [12, 32, 1] ┆ [-12, 1]      ┆ … ┆ ichardRay ┆ 22           ┆ 0.25        ┆ 0.0       │
│ Alice   ┆ half  ┆ []          ┆ [43]          ┆ … ┆ liceAay   ┆ 12           ┆ 0.0         ┆ 0.0       │
│ Bob     ┆ red   ┆ [1, -2]     ┆ [876, -45, 9] ┆ … ┆ obBay     ┆ 8            ┆ 0.0         ┆ 0.0       │
└─────────┴───────┴─────────────┴───────────────┴───┴───────────┴──────────────┴─────────────┴───────────┘
```

It might be necessary for `[extend_polars_python_dispatch](https://github.com/pola-rs/pyo3-polars/tree/main/example/extend_polars_python_dispatch)`, but that has its own requirements file