### PR TITLE
feat: support kwargs for field functions

### DIFF
--- a/example/derive_expression/expression_lib/Cargo.toml
+++ b/example/derive_expression/expression_lib/Cargo.toml
@@ -9,7 +9,7 @@ name = "expression_lib"
 crate-type = ["cdylib"]
 
 [dependencies]
-polars = { workspace = true, features = ["fmt", "dtype-date"], default-features = false }
+polars = { workspace = true, features = ["fmt", "dtype-date", "timezones"], default-features = false }
 pyo3-polars = { version = "*", path = "../../../pyo3-polars", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 rayon = "1.7.0"

--- a/example/derive_expression/expression_lib/expression_lib/__init__.py
+++ b/example/derive_expression/expression_lib/expression_lib/__init__.py
@@ -91,6 +91,14 @@ class DateUtil:
             is_elementwise=True,
         )
 
+    # Note that this already exists in Polars. It is just for explanatory
+    # purposes.
+    def change_time_zone(self, tz: str = "Europe/Amsterdam") -> pl.Expr:
+        return self._expr.register_plugin(
+            lib=lib, symbol="change_time_zone", is_elementwise=True, kwargs={"tz": tz}
+        )
+
+
 @pl.api.register_expr_namespace("panic")
 class Panic:
     def __init__(self, expr: pl.Expr):

--- a/example/derive_expression/expression_lib/src/expressions.rs
+++ b/example/derive_expression/expression_lib/src/expressions.rs
@@ -197,7 +197,7 @@ fn convert_timezone(input_fields: &[Field], kwargs: TimeZone) -> PolarsResult<Fi
 }
 
 #[polars_expr(output_type_func_with_kwargs=convert_timezone)]
-fn change_time_unit(input: &[Series], kwargs: TimeZone) -> PolarsResult<Series> {
+fn change_time_zone(input: &[Series], kwargs: TimeZone) -> PolarsResult<Series> {
     let input = &input[0];
     let ca = input.datetime()?;
 

--- a/example/derive_expression/expression_lib/src/expressions.rs
+++ b/example/derive_expression/expression_lib/src/expressions.rs
@@ -82,7 +82,10 @@ fn pig_latinnify_with_paralellism(
                 })
                 .collect();
 
-            Ok(StringChunked::from_chunk_iter(ca.name(), chunks.into_iter().flatten()).into_series())
+            Ok(
+                StringChunked::from_chunk_iter(ca.name(), chunks.into_iter().flatten())
+                    .into_series(),
+            )
         })
     }
 }
@@ -179,4 +182,26 @@ fn is_leap_year(input: &[Series]) -> PolarsResult<Series> {
 #[polars_expr(output_type=Boolean)]
 fn panic(_input: &[Series]) -> PolarsResult<Series> {
     todo!()
+}
+
+#[derive(Deserialize)]
+struct TimeZone {
+    tz: String,
+}
+
+fn convert_timezone(input_fields: &[Field], kwargs: TimeZone) -> PolarsResult<Field> {
+    FieldsMapper::new(input_fields).try_map_dtype(|dtype| match dtype {
+        DataType::Datetime(tu, _) => Ok(DataType::Datetime(*tu, Some(kwargs.tz.clone()))),
+        _ => polars_bail!(ComputeError: "expected datetime"),
+    })
+}
+
+#[polars_expr(output_type_func_with_kwargs=convert_timezone)]
+fn change_time_unit(input: &[Series], kwargs: TimeZone) -> PolarsResult<Series> {
+    let input = &input[0];
+    let ca = input.datetime()?;
+
+    ca.clone()
+        .convert_time_zone(kwargs.tz)
+        .map(|ca| ca.into_series())
 }

--- a/example/derive_expression/run.py
+++ b/example/derive_expression/run.py
@@ -1,12 +1,13 @@
 import polars as pl
 from expression_lib import *
-from datetime import date
+from datetime import date, datetime, timezone
 
 df = pl.DataFrame(
     {
         "names": ["Richard", "Alice", "Bob"],
         "moons": ["full", "half", "red"],
         "dates": [date(2023, 1, 1), date(2024, 1, 1), date(2025, 1, 1)],
+        "datetime": [datetime.now(tz=timezone.utc)] * 3,
         "dist_a": [[12, 32, 1], [], [1, -2]],
         "dist_b": [[-12, 1], [43], [876, -45, 9]],
         "floats": [5.6, -1245.8, 242.224],
@@ -22,6 +23,7 @@ out = df.with_columns(
     jaccard_sim=pl.col("dist_a").dist.jaccard_similarity("dist_b"),
     haversine=pl.col("floats").dist.haversine("floats", "floats", "floats", "floats"),
     leap_year=pl.col("dates").date_util.is_leap_year(),
+    new_tz=pl.col("datetime").date_util.change_time_zone(),
     appended_args=pl.col("names").language.append_args(
         float_arg=11.234,
         integer_arg=93,
@@ -48,9 +50,7 @@ except pl.ComputeError as e:
 
 
 try:
-    out.with_columns(
-        pl.col("names").panic.panic()
-    )
+    out.with_columns(pl.col("names").panic.panic())
 except pl.ComputeError as e:
     assert "the plugin panicked" in str(e)
 

--- a/pyo3-polars-derive/src/attr.rs
+++ b/pyo3-polars-derive/src/attr.rs
@@ -21,11 +21,14 @@ impl<K: Parse, V: Parse> Parse for KeyWordAttribute<K, V> {
 
 pub type OutputAttribute = KeyWordAttribute<keywords::output_type, Ident>;
 pub type OutputFuncAttribute = KeyWordAttribute<keywords::output_type_func, Ident>;
+pub type OutputFuncAttributeWithKwargs =
+    KeyWordAttribute<keywords::output_type_func_with_kwargs, Ident>;
 
 #[derive(Default, Debug)]
 pub struct ExprsFunctionOptions {
     pub output_dtype: Option<Ident>,
     pub output_type_fn: Option<Ident>,
+    pub output_type_fn_kwargs: Option<Ident>,
 }
 
 impl Parse for ExprsFunctionOptions {
@@ -41,6 +44,9 @@ impl Parse for ExprsFunctionOptions {
             } else if lookahead.peek(keywords::output_type_func) {
                 let attr = input.parse::<OutputFuncAttribute>()?;
                 options.output_type_fn = Some(attr.value)
+            } else if lookahead.peek(keywords::output_type_func_with_kwargs) {
+                let attr = input.parse::<OutputFuncAttributeWithKwargs>()?;
+                options.output_type_fn_kwargs = Some(attr.value)
             } else {
                 panic!("didn't recognize attribute")
             }

--- a/pyo3-polars-derive/src/keywords.rs
+++ b/pyo3-polars-derive/src/keywords.rs
@@ -1,2 +1,3 @@
 syn::custom_keyword!(output_type);
 syn::custom_keyword!(output_type_func);
+syn::custom_keyword!(output_type_func_with_kwargs);


### PR DESCRIPTION
closes #58

We cannot introspect the passed function so  we must give it a new name. You must pass: 

```rust
#[polars_expr(output_type_func_with_kwargs=<function_name>)]
```

Upstream changes; https://github.com/pola-rs/polars/pull/13944