### PR TITLE
use abi3-py38 feature in example

### DIFF
--- a/example/derive_expression/expression_lib/Cargo.toml
+++ b/example/derive_expression/expression_lib/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 polars = { workspace = true, features = ["fmt", "dtype-date", "timezones"], default-features = false }
+pyo3 = { version = "0.20", features = ["abi3-py38"] }
 pyo3-polars = { version = "*", path = "../../../pyo3-polars", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 rayon = "1.7.0"


### PR DESCRIPTION
With reference to https://github.com/pola-rs/polars-xdt/discussions/59, maybe the example repo should have `abi-py38`, so that people using this as a basis to distribute plugins from distribute widely installable ones?