### PR TITLE
Switch to newer PyO3 0.21 APIs (Bound<> and friends)

### DIFF
--- a/example/extend_polars_python_dispatch/extend_polars/src/lib.rs
+++ b/example/extend_polars_python_dispatch/extend_polars/src/lib.rs
@@ -31,7 +31,7 @@ fn lazy_parallel_jaccard(pydf: PyLazyFrame, col_a: &str, col_b: &str) -> PyResul
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn extend_polars(_py: Python, m: &PyModule) -> PyResult<()> {
+fn extend_polars(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parallel_jaccard, m)?)?;
     m.add_function(wrap_pyfunction!(lazy_parallel_jaccard, m)?)?;
     m.add_function(wrap_pyfunction!(debug, m)?)?;

--- a/pyo3-polars/src/ffi/to_rust.rs
+++ b/pyo3-polars/src/ffi/to_rust.rs
@@ -4,7 +4,7 @@ use polars::prelude::*;
 use pyo3::ffi::Py_uintptr_t;
 use pyo3::prelude::*;
 
-pub fn array_to_rust(obj: &PyAny) -> PyResult<ArrayRef> {
+pub fn array_to_rust(obj: &Bound<PyAny>) -> PyResult<ArrayRef> {
     // prepare a pointer to receive the Array struct
     let array = Box::new(ffi::ArrowArray::empty());
     let schema = Box::new(ffi::ArrowSchema::empty());

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-03-28"
+channel = "nightly-2024-05-14"


### PR DESCRIPTION
Fixes #81 

Some of the work was already done, this removes usage of some of the deprecated APIs.