### PR TITLE
perf: set compat_level when calling to_arrow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ polars-core = { version = "0.41.0", default-features = false }
 polars-ffi = { version = "0.41.0", default-features = false }
 polars-plan = { version = "0.41.0", default-feautres = false }
 polars-lazy = { version = "0.41.0", default-features = false }
+
+[patch.crates-io]
+polars = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }
+polars-core = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }
+polars-ffi = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }
+polars-plan = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }
+polars-lazy = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ polars-plan = { version = "0.41.0", default-feautres = false }
 polars-lazy = { version = "0.41.0", default-features = false }
 
 [patch.crates-io]
-polars = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }
-polars-core = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }
-polars-ffi = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }
-polars-plan = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }
-polars-lazy = { git = "https://github.com/ruihe774/polars.git", branch = "future-version" }
+polars = { git = "https://github.com/pola-rs/polars.git" }
+polars-core = { git = "https://github.com/pola-rs/polars.git" }
+polars-ffi = { git = "https://github.com/pola-rs/polars.git" }
+polars-plan = { git = "https://github.com/pola-rs/polars.git" }
+polars-lazy = { git = "https://github.com/pola-rs/polars.git" }

--- a/pyo3-polars-derive/src/lib.rs
+++ b/pyo3-polars-derive/src/lib.rs
@@ -241,7 +241,7 @@ fn create_field_function(
 
                 match result {
                     Ok(out) => {
-                        let out = polars_core::export::arrow::ffi::export_field_to_c(&out.to_arrow(true));
+                        let out = polars_core::export::arrow::ffi::export_field_to_c(&out.to_arrow(CompatLevel::newest()));
                         *return_value = out;
                     },
                     Err(err) => {
@@ -278,7 +278,7 @@ fn create_field_function_from_with_dtype(
             let mapper = polars_plan::dsl::FieldsMapper::new(&inputs);
             let dtype = polars_core::datatypes::DataType::#dtype;
             let out = mapper.with_dtype(dtype).unwrap();
-            let out = polars_core::export::arrow::ffi::export_field_to_c(&out.to_arrow(true));
+            let out = polars_core::export::arrow::ffi::export_field_to_c(&out.to_arrow(CompatLevel::newest()));
             *return_value = out;
         }
     )

--- a/pyo3-polars/src/error.rs
+++ b/pyo3-polars/src/error.rs
@@ -36,12 +36,8 @@ impl std::convert::From<PyPolarsErr> for PyErr {
                 PolarsError::StringCacheMismatch(err) => {
                     StringCacheMismatchError::new_err(err.to_string())
                 }
-                PolarsError::SQLInterface(err) => {
-                    SQLInterface::new_err(err.to_string())
-                },
-                PolarsError::SQLSyntax(err) => {
-                    SQLSyntax::new_err(err.to_string())
-                }
+                PolarsError::SQLInterface(err) => SQLInterface::new_err(err.to_string()),
+                PolarsError::SQLSyntax(err) => SQLSyntax::new_err(err.to_string()),
                 PolarsError::Context { error, .. } => convert(error),
             }
         }

--- a/pyo3-polars/src/lib.rs
+++ b/pyo3-polars/src/lib.rs
@@ -54,7 +54,7 @@ use polars::export::arrow;
 use polars::prelude::*;
 use pyo3::ffi::Py_uintptr_t;
 use pyo3::prelude::*;
-
+use pyo3::types::PyDict;
 #[cfg(feature = "lazy")]
 use {polars_lazy::frame::LazyFrame, polars_plan::plans::DslPlan};
 
@@ -126,7 +126,9 @@ impl<'a> FromPyObject<'a> for PySeries {
         let py_name = name.str()?;
         let name = py_name.to_cow()?;
 
-        let arr = ob.call_method0("to_arrow")?;
+        let kwargs = PyDict::new_bound(ob.py());
+        kwargs.set_item("future", true)?;
+        let arr = ob.call_method("to_arrow", (), Some(&kwargs))?;
         let arr = ffi::to_rust::array_to_rust(&arr)?;
         Ok(PySeries(
             Series::try_from((&*name, arr)).map_err(PyPolarsErr::from)?,

--- a/pyo3-polars/src/lib.rs
+++ b/pyo3-polars/src/lib.rs
@@ -172,7 +172,10 @@ impl IntoPy<PyObject> for PySeries {
     fn into_py(self, py: Python<'_>) -> PyObject {
         let polars = py.import_bound("polars").expect("polars not installed");
         let s = polars.getattr("Series").unwrap();
-        match s.getattr("_import_arrow_from_c") {
+        match s
+            .getattr("_import_arrow_from_c")
+            .or_else(|_| s.getattr("_import_from_c"))
+        {
             // Go via polars
             Ok(import_arrow_from_c) => {
                 // Get supported compatibility level


### PR DESCRIPTION
This depends on https://github.com/pola-rs/polars/pull/17371.

In my naive benchmark, with large string columns, it improves the speed to ~10x.