### PR TITLE
chore: update rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-05-14"
+channel = "nightly-2024-06-23"


### PR DESCRIPTION
This PR upgrades rust toolchain to nightly-2024-06-23, which is used by polars, so that I do not have to install two nightly toolchains.