### PR TITLE
fix feature for pylist

### DIFF
--- a/pyo3-polars/src/types.rs
+++ b/pyo3-polars/src/types.rs
@@ -19,7 +19,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyDict;
-#[cfg(feature = "dtype-full")]
+#[cfg(feature = "dtype-struct")]
 use pyo3::types::PyList;
 
 #[cfg(feature = "dtype-categorical")]


### PR DESCRIPTION
PyList is only used in the `DataType::Struct` arm of this file - was this meant to be `"dtype-struct"`?

I noticed this while updating the plugins tutorial

Without this, I get:
```
error[E0433]: failed to resolve: use of undeclared type `PyList`
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-polars-0.16.0/src/types.rs:475:30
    |
475 |                 let fields = PyList::new_bound(py, iter);
    |                              ^^^^^^ use of undeclared type `PyList`
    |
help: a struct with a similar name exists
    |
475 |                 let fields = PyDict::new_bound(py, iter);
    |                              ~~~~~~
help: consider importing this struct
    |
1   + use pyo3::types::PyList;
```