### PR TITLE
Fix compilation errors for features: dtype-struct and dtype-full

### DIFF
--- a/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1"
 [features]
 lazy = ["polars/serde-lazy", "polars-plan", "polars-lazy/serde", "ciborium"]
 derive = ["pyo3-polars-derive", "polars-plan", "polars-ffi", "serde-pickle", "serde"]
-dtype-full = ["polars/dtype-full", "dtype-decimal", "dtype-array", "dtype-categorical"]
+dtype-full = ["polars/dtype-full", "dtype-decimal", "dtype-array", "dtype-struct", "dtype-categorical"]
 object = ["polars/object"]
 dtype-decimal = ["polars/dtype-decimal"]
 dtype-struct = ["polars/dtype-struct"]

--- a/pyo3-polars/src/types.rs
+++ b/pyo3-polars/src/types.rs
@@ -19,7 +19,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyDict;
-#[cfg(feature = "dtype-full")]
+#[cfg(feature = "dtype-struct")]
 use pyo3::types::PyList;
 
 #[cfg(feature = "dtype-categorical")]
@@ -460,7 +460,7 @@ impl ToPyObject for PyDataType {
                 let categories = rev_map.as_ref().unwrap().get_categories();
                 let class = pl.getattr(intern!(py, "Enum")).unwrap();
                 let s = Series::from_arrow("category", categories.clone().boxed()).unwrap();
-                let series = to_series(py, s.into());
+                let series = to_series(py, PySeries(s));
                 return class.call1((series,)).unwrap().into();
             }
             DataType::Time => pl.getattr(intern!(py, "Time")).unwrap().into(),
@@ -577,7 +577,9 @@ impl<'py> FromPyObject<'py> for PyDataType {
                 let ordering = match ordering.extract::<&str>()? {
                     "physical" => CategoricalOrdering::Physical,
                     "lexical" => CategoricalOrdering::Lexical,
-                    ordering => PyValueError::new_err(format!("invalid ordering argument: {ordering}"))
+                    ordering => {
+                        return Err(PyValueError::new_err(format!("invalid ordering argument: {ordering}")))
+                    }
                 };
 
                 DataType::Categorical(None, ordering)


### PR DESCRIPTION
When compiling with dtype-struct feature:

```sh
   Compiling pyo3-polars v0.16.0 (/Users/luke/GitHub/pyo3-polars/pyo3-polars)
error[E0433]: failed to resolve: use of undeclared type `PyList`
   --> /Users/luke/GitHub/pyo3-polars/pyo3-polars/src/types.rs:475:30
    |
475 |                 let fields = PyList::new_bound(py, iter);
    |                              ^^^^^^ use of undeclared type `PyList`
    |
help: a struct with a similar name exists
    |
475 |                 let fields = PyDict::new_bound(py, iter);
    |                              ~~~~~~
help: consider importing this struct
    |
1   + use pyo3::types::PyList;
    |

For more information about this error, try `rustc --explain E0433`.
error: could not compile `pyo3-polars` (lib) due to 1 previous error
```

When compiling with the dtype-full feature:
```sh
   Compiling pyo3-polars v0.16.0 (/Users/luke/GitHub/pyo3-polars/pyo3-polars)
warning: unused import: `pyo3::types::PyList`
  --> /Users/luke/GitHub/pyo3-polars/pyo3-polars/src/types.rs:23:5
   |
23 | use pyo3::types::PyList;
   |     ^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

error[E0277]: the trait bound `PySeries: From<polars::prelude::Series>` is not satisfied
```

This PR fixes these compilation errors and the dtype-struct feature is now implied by dtype-full. The dtype-struct feature is needed to resolve #98 when the performant feature is enabled for polars.