### PR TITLE
fix: `dtype-categorical` feature compile issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,24 @@ jobs:
       - run: cargo test
         working-directory: pyo3-polars
 
+      - run: cargo test --all-features
+        working-directory: pyo3-polars
+
+      - run: cargo test --features dtype-categorical
+        working-directory: pyo3-polars
+
+      - run: cargo test --features dtype-full
+        working-directory: pyo3-polars
+
+      - run: cargo test --features dtype-struct
+        working-directory: pyo3-polars
+
+      - run: cargo test --features dtype-array
+        working-directory: pyo3-polars
+
+      - run: cargo test --features lazy
+        working-directory: pyo3-polars
+
       - run: make install
         working-directory: example/extend_polars_python_dispatch
 

--- a/pyo3-polars/src/types.rs
+++ b/pyo3-polars/src/types.rs
@@ -341,7 +341,7 @@ impl IntoPy<PyObject> for PyExpr {
     }
 }
 
-#[cfg(feature = "dtype-full")]
+#[cfg(any(feature = "dtype-full", feature = "dtype-categorical"))]
 pub(crate) fn to_series(py: Python, s: PySeries) -> PyObject {
     let series = SERIES.bind(py);
     let constructor = series


### PR DESCRIPTION
When enables `dtype-categorical`, the new `0.16.1` version of `pyo3-polars` still fail to compile. Here is what this PR is about:
- fixs compilation issue for `dtype-categorical` feature. 
- add test for selected features set, like `dtype-categorical` or `dtype-full` alone, and all features 