### PR TITLE
Fix typo in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 polars = { version = "0.45.0", default-features = false }
 polars-core = { version = "0.45.0", default-features = false }
 polars-ffi = { version = "0.45.0", default-features = false }
-polars-plan = { version = "0.45.0", default-feautres = false }
+polars-plan = { version = "0.45.0", default-features = false }
 polars-lazy = { version = "0.45.0", default-features = false }
 
 [workspace.dependencies.arrow]


### PR DESCRIPTION
Just fixes a typo that was causing a warning:

```
unused manifest key: workspace.dependencies.polars-plan.default-feautres
```
