### PR TITLE
refactor for pyo3 0.23.3; 

### DIFF
--- a/example/derive_expression/expression_lib/Cargo.toml
+++ b/example/derive_expression/expression_lib/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 polars = { workspace = true, features = ["fmt", "dtype-date", "timezones"], default-features = false }
-pyo3 = { version = "0.22", features = ["abi3-py38"] }
+pyo3 = { version = "0.23.3", features = ["abi3-py312"] }
 pyo3-polars = { version = "*", path = "../../../pyo3-polars", features = ["derive"] }
 rayon = "1.7.0"
 serde = { version = "1", features = ["derive"] }

--- a/example/derive_expression/expression_lib/pyproject.toml
+++ b/example/derive_expression/expression_lib/pyproject.toml
@@ -3,8 +3,9 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
+version = "0.0.1"
 name = "expression_lib"
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 classifiers = [
   "Programming Language :: Rust",
   "Programming Language :: Python :: Implementation :: CPython",

--- a/example/extend_polars_python_dispatch/extend_polars/Cargo.toml
+++ b/example/extend_polars_python_dispatch/extend_polars/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 polars = { workspace = true, features = ["fmt"] }
 polars-core = { workspace = true }
 polars-lazy = { workspace = true }
-pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3 = { version = "0.23", features = ["extension-module"] }
 pyo3-polars = { version = "*", path = "../../../pyo3-polars", features = ["lazy"] }
 rayon = "1.10"

--- a/example/extend_polars_python_dispatch/extend_polars/src/lib.rs
+++ b/example/extend_polars_python_dispatch/extend_polars/src/lib.rs
@@ -33,7 +33,7 @@ fn lazy_parallel_jaccard(pydf: PyLazyFrame, col_a: &str, col_b: &str) -> PyResul
 }
 
 /// A Python module implemented in Rust.
-#[pymodule]
+#[pymodule(name = "expression_lib")]
 fn extend_polars(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parallel_jaccard, m)?)?;
     m.add_function(wrap_pyfunction!(lazy_parallel_jaccard, m)?)?;

--- a/example/io_plugin/io_plugin/Cargo.toml
+++ b/example/io_plugin/io_plugin/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 polars = { workspace = true, features = ["fmt", "dtype-date", "timezones", "lazy"], default-features = false }
-pyo3 = { version = "0.22", features = ["abi3-py38"] }
+pyo3 = { version = "0.23.3", features = ["abi3-py312"] }
 pyo3-polars = { version = "*", path = "../../../pyo3-polars", features = ["derive", "lazy"] }
 rand = { version = "0.8.5", features = [] }

--- a/pyo3-polars-derive/Cargo.toml
+++ b/pyo3-polars-derive/Cargo.toml
@@ -25,4 +25,5 @@ quote = "1.0"
 syn = { version = "2", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
+pyo3-polars = { path = "../pyo3-polars" }
 trybuild = { version = "1", features = ["diff"] }

--- a/pyo3-polars-derive/tests/01.rs
+++ b/pyo3-polars-derive/tests/01.rs
@@ -1,5 +1,5 @@
 use polars_core::error::PolarsResult;
-use polars_core::prelude::{Field, Series};
+use polars_core::prelude::{CompatLevel, Field, Series};
 use polars_plan::dsl::FieldsMapper;
 use pyo3_polars_derive::polars_expr;
 
@@ -7,11 +7,11 @@ fn horizontal_product_output(input_fields: &[Field]) -> PolarsResult<Field> {
     FieldsMapper::new(input_fields).map_to_supertype()
 }
 
-#[polars_expr(type_func=horizontal_product_output)]
-fn horizontal_product(series: &[Series], _kwargs: Option<&str>) -> PolarsResult<Series> {
+#[polars_expr(output_type_func=horizontal_product_output)]
+fn horizontal_product(series: &[Series]) -> PolarsResult<Series> {
     let mut acc = series[0].clone();
     for s in &series[1..] {
-        acc = &acc * s
+        acc = (&acc * s)?;
     }
     Ok(acc)
 }

--- a/pyo3-polars-derive/tests/02.rs
+++ b/pyo3-polars-derive/tests/02.rs
@@ -1,12 +1,12 @@
 use polars_core::error::PolarsResult;
-use polars_core::prelude::Series;
+use polars_core::prelude::{CompatLevel, Series};
 use pyo3_polars_derive::polars_expr;
 
 #[polars_expr(output_type=Int32)]
-fn horizontal_product(series: &[Series], _kwargs: Option<&str>) -> PolarsResult<Series> {
+fn horizontal_product(series: &[Series]) -> PolarsResult<Series> {
     let mut acc = series[0].clone();
     for s in &series[1..] {
-        acc = &acc * s
+        acc = (&acc * s)?;
     }
     Ok(acc)
 }

--- a/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/Cargo.toml
@@ -10,19 +10,18 @@ description = "Expression plugins and PyO3 types for polars"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ciborium = { version = "0.2.1", optional = true }
+ciborium = { version = "0.2", optional = true }
 libc = "0.2" # pyo3 depends on libc already, so this does not introduce an extra dependence.
-once_cell = "1"
 polars = { workspace = true, default-features = false }
 polars-core = { workspace = true, default-features = false }
 polars-ffi = { workspace = true, optional = true }
 polars-lazy = { workspace = true, optional = true }
 polars-plan = { workspace = true, optional = true }
-pyo3 = "0.22"
-pyo3-polars-derive = { version = "0.13.0", path = "../pyo3-polars-derive", optional = true }
+pyo3 = "0.23.3"
+pyo3-polars-derive = { version = "0.13", path = "../pyo3-polars-derive", optional = true }
 serde = { version = "1", optional = true }
 serde-pickle = { version = "1", optional = true }
-thiserror = "1"
+thiserror = "2"
 
 [features]
 lazy = ["polars/serde-lazy", "polars-plan", "polars-lazy/serde", "ciborium"]

--- a/pyo3-polars/src/error.rs
+++ b/pyo3-polars/src/error.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)] // note - only for create_exception ... document the rest
+
 use std::fmt::{Debug, Formatter};
 
 use polars::prelude::PolarsError;
@@ -6,10 +8,13 @@ use pyo3::exceptions::{PyException, PyIOError, PyIndexError, PyRuntimeError, PyV
 use pyo3::prelude::*;
 use thiserror::Error;
 
+/// Error types for `pyo3-polars`
 #[derive(Error)]
 pub enum PyPolarsErr {
+    /// A wrapped error from the Polars Rust crate
     #[error(transparent)]
     Polars(#[from] PolarsError),
+    /// A non-polars error from `pyo3-polars`
     #[error("{0}")]
     Other(String),
 }

--- a/pyo3-polars/src/export.rs
+++ b/pyo3-polars/src/export.rs
@@ -1,3 +1,4 @@
+//! exports `polars_core`, `polars_ffi`, and `polars_plan`
 pub use polars_core;
 pub use polars_ffi;
 pub use polars_plan;

--- a/pyo3-polars/src/ffi/to_py.rs
+++ b/pyo3-polars/src/ffi/to_py.rs
@@ -6,9 +6,9 @@ use pyo3::prelude::*;
 /// Arrow array to Python.
 pub(crate) fn to_py_array(
     array: ArrayRef,
-    py: Python,
+    // py: Python<'py>, // unused ?
     pyarrow: Bound<'_, PyModule>,
-) -> PyResult<PyObject> {
+) -> PyResult<Bound<'_, PyAny>> {
     let schema = Box::new(ffi::export_field_to_c(&ArrowField::new(
         "".into(),
         array.dtype().clone(),
@@ -24,5 +24,5 @@ pub(crate) fn to_py_array(
         (array_ptr as Py_uintptr_t, schema_ptr as Py_uintptr_t),
     )?;
 
-    Ok(array.to_object(py))
+    Ok(array)
 }

--- a/pyo3-polars/src/ffi/to_rust.rs
+++ b/pyo3-polars/src/ffi/to_rust.rs
@@ -4,6 +4,7 @@ use polars::prelude::*;
 use pyo3::ffi::Py_uintptr_t;
 use pyo3::prelude::*;
 
+/// attempt to convert a python arrow array ffi object to a rust arrow array reference
 pub fn array_to_rust(obj: &Bound<PyAny>) -> PyResult<ArrayRef> {
     // prepare a pointer to receive the Array struct
     let array = Box::new(ffi::ArrowArray::empty());

--- a/pyo3-polars/src/lib.rs
+++ b/pyo3-polars/src/lib.rs
@@ -41,6 +41,7 @@
 //! })
 //! out_df = my_cool_function(df)
 //! ```
+#![deny(missing_docs)]
 mod alloc;
 #[cfg(feature = "derive")]
 pub mod derive;
@@ -50,14 +51,19 @@ pub mod export;
 mod ffi;
 mod types;
 
+use std::sync::LazyLock;
+
 pub use crate::alloc::PolarsAllocator;
-use once_cell::sync::Lazy;
+// use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 pub use types::*;
 
-pub(crate) static POLARS: Lazy<PyObject> = Lazy::new(|| {
-    Python::with_gil(|py| PyModule::import_bound(py, "polars").unwrap().to_object(py))
+pub(crate) static POLARS: LazyLock<Py<PyModule>> = LazyLock::new(|| {
+    Python::with_gil(|py| {
+        let x = PyModule::import(py, "polars").unwrap().unbind();
+        x
+    })
 });
 
-pub(crate) static SERIES: Lazy<PyObject> =
-    Lazy::new(|| Python::with_gil(|py| POLARS.getattr(py, "Series").unwrap()));
+pub(crate) static SERIES: LazyLock<PyObject> =
+    LazyLock::new(|| Python::with_gil(|py| POLARS.getattr(py, "Series").unwrap()));


### PR DESCRIPTION
also does:
remove once_cell dependency;
deny missing_docs; 
use output_type_func in derive/tests/01

NOTE: i can't get this to compile on my rig due to issues with rust-lld not finding some python symbols, not sure what's the deal with that, but you're welcome to try to build this on your machine and see how it works. 

just wanted to push what i did so others could refer to it

this would enable support for pyo3 0.23.3 using `IntoPyObject` and fix all those deprecation warnings

additionally i added a lint, `#![deny(missing_docs)]` so the project won't compile with anything missing documentation, in my experience this aids accessibility

i had issues with `type_func=` in the derive crate, so i changed it to `output_type_func` to make the compiler STFU, but i don't really know what that test was for; it's possible there has been some regression in the derive macro for `type_func`; please explain

I'm not the best at checking github notifications and am in crunch time for a project release, so if you want edits to this PR, please go ahead and edit it!

would close 
https://github.com/pola-rs/pyo3-polars/issues/124
https://github.com/pola-rs/pyo3-polars/issues/119

relevant to 
https://github.com/pola-rs/pyo3-polars/issues/112
https://github.com/pola-rs/pyo3-polars/pull/37

cheers, happy new year, i'm personally trying to switch more to pure rust but am still using this sometimes so just wanted to contribute local changes upstream... please give me pointers if i screwed something up!