### PR TITLE
Use PyCapsule in impl FromPyObject for PySeries

### DIFF
--- a/pyo3-polars/src/ffi/to_rust.rs
+++ b/pyo3-polars/src/ffi/to_rust.rs
@@ -1,8 +1,12 @@
 use crate::error::PyPolarsErr;
+use crate::PySeries;
 use polars::prelude::*;
+use polars_arrow::array::Array;
 use polars_arrow::ffi;
+use pyo3::exceptions::PyValueError;
 use pyo3::ffi::Py_uintptr_t;
 use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
 
 pub fn array_to_rust(obj: &Bound<PyAny>) -> PyResult<ArrayRef> {
     // prepare a pointer to receive the Array struct
@@ -24,4 +28,67 @@ pub fn array_to_rust(obj: &Bound<PyAny>) -> PyResult<ArrayRef> {
         let array = ffi::import_array_from_c(*array, field.dtype).map_err(PyPolarsErr::from)?;
         Ok(array)
     }
+}
+
+/// Import `__arrow_c_stream__` across Python boundary.
+pub fn call_arrow_c_stream<'py>(ob: &'py Bound<PyAny>) -> PyResult<Bound<'py, PyCapsule>> {
+    if !ob.hasattr("__arrow_c_stream__")? {
+        return Err(PyValueError::new_err(
+            "Expected an object with dunder __arrow_c_stream__",
+        ));
+    }
+
+    let capsule = ob.getattr("__arrow_c_stream__")?.call0()?.downcast_into()?;
+    Ok(capsule)
+}
+
+/// Validate PyCapsule has provided name
+pub fn validate_pycapsule_name(capsule: &Bound<PyCapsule>, expected_name: &str) -> PyResult<()> {
+    let capsule_name = capsule.name()?;
+    if let Some(capsule_name) = capsule_name {
+        let capsule_name = capsule_name.to_str()?;
+        if capsule_name != expected_name {
+            return Err(PyValueError::new_err(format!(
+                "Expected name '{}' in PyCapsule, instead got '{}'",
+                expected_name, capsule_name
+            )));
+        }
+    } else {
+        return Err(PyValueError::new_err(
+            "Expected schema PyCapsule to have name set.",
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn import_stream_pycapsule(capsule: &Bound<PyCapsule>) -> PyResult<PySeries> {
+    validate_pycapsule_name(capsule, "arrow_array_stream")?;
+    // # Safety
+    // capsule holds a valid C ArrowArrayStream pointer, as defined by the Arrow PyCapsule
+    // Interface
+    let mut stream = unsafe {
+        // Takes ownership of the pointed to ArrowArrayStream
+        // This acts to move the data out of the capsule pointer, setting the release callback to NULL
+        let stream_ptr = Box::new(std::ptr::replace(
+            capsule.pointer() as _,
+            ffi::ArrowArrayStream::empty(),
+        ));
+        ffi::ArrowArrayStreamReader::try_new(stream_ptr)
+            .map_err(|err| PyValueError::new_err(err.to_string()))?
+    };
+
+    let mut produced_arrays: Vec<Box<dyn Array>> = vec![];
+    while let Some(array) = unsafe { stream.next() } {
+        produced_arrays.push(array.unwrap());
+    }
+
+    // Series::try_from fails for an empty vec of chunks
+    let s = if produced_arrays.is_empty() {
+        let polars_dt = DataType::from_arrow_field(stream.field());
+        Series::new_empty(stream.field().name.clone(), &polars_dt)
+    } else {
+        Series::try_from((stream.field(), produced_arrays)).unwrap()
+    };
+    Ok(PySeries(s))
 }

--- a/pyo3-polars/src/types.rs
+++ b/pyo3-polars/src/types.rs
@@ -4,6 +4,7 @@ use super::*;
 
 use crate::error::PyPolarsErr;
 use crate::ffi::to_py::to_py_array;
+use crate::ffi::to_rust::{call_arrow_c_stream, import_stream_pycapsule};
 use polars_arrow as arrow;
 use polars_core::datatypes::{CompatLevel, DataType};
 use polars_core::prelude::*;
@@ -170,6 +171,9 @@ impl AsRef<Schema> for PySchema {
 
 impl<'a> FromPyObject<'a> for PySeries {
     fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+        if let Ok(capsule) = call_arrow_c_stream(ob) {
+            return import_stream_pycapsule(&capsule);
+        }
         let ob = ob.call_method0("rechunk")?;
 
         let name = ob.getattr("name")?;


### PR DESCRIPTION
I just copied that code straight from `polars-python`. The goal is to avoid making `pyarrow` a strict dependency when calling this crate (and an strange fight to find where that `ModuleNotFoundError: No module named 'pyarrow'` came from since you didn't import it in your python code).