### PR TITLE
Fix missing project.version error for maturin >= 1.8

### DIFF
--- a/example/derive_expression/expression_lib/pyproject.toml
+++ b/example/derive_expression/expression_lib/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "expression_lib"
+dynamic = ["version"]
 requires-python = ">=3.8"
 classifiers = [
   "Programming Language :: Rust",

--- a/example/io_plugin/io_plugin/pyproject.toml
+++ b/example/io_plugin/io_plugin/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "io_plugin"
+dynamic = ["version"]
 requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Rust",


### PR DESCRIPTION
Since Maturin 1.8, running `make install` for io_plugin or derive_expression results in:
```sh
⚠️  Warning: `project.version` field is required in pyproject.toml unless it is present in the `project.dynamic` list
💥 maturin failed
  Caused by: Cannot build without valid version information. You need to specify either `project.version` or `project.dynamic = ["version"]` in pyproject.toml.
make: *** [install] Error 1
```
See https://github.com/PyO3/maturin/issues/2416

This simple fix sets `project.dynamic = ["version"]` in pyproject.toml, which the default for `maturin init` with recent versions.