### PR TITLE
CI: Update mozilla-actions/sccache-action to 0.0.8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Rust
         run: rustup show
 
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: mozilla-actions/sccache-action@v0.0.8
 
       - run: cargo test
         working-directory: pyo3-polars

--- a/example/extend_polars_python_dispatch/requirements.txt
+++ b/example/extend_polars_python_dispatch/requirements.txt
@@ -1,2 +1,2 @@
 maturin
-polars[pyarrow]<1.22
+polars[pyarrow]

--- a/example/extend_polars_python_dispatch/requirements.txt
+++ b/example/extend_polars_python_dispatch/requirements.txt
@@ -1,2 +1,2 @@
 maturin
-polars[pyarrow]
+polars[pyarrow]<1.22


### PR DESCRIPTION
The existing version (0.0.3) of sccache-action uses a decommissioned version of the GitHub cache action.

Error seen in #134.

(REVERTED: Will not be needed after polars dep is updated to 0.47 is on main, #137) Also restricted python polars version <1.22 in `example/extend_polars_python_dispatch/requirements.txt` to work around incompatibility until the next rust polars release. Error was:
```
    print(lazy_parallel_jaccard(df.lazy(), "list_a", "list_b").collect())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: BindingsError: "Error when deserializing LazyFrame. This may be due to mismatched polars versions. invalid value: integer `1598837572`, expected variant index 0 <= i < 18"```