### PR TITLE
chore: Use new unreleased Rust Polars 0.48.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,24 +9,27 @@ members = [
 ]
 
 [workspace.dependencies]
-polars = { version = "0.48.0", default-features = false }
-polars-core = { version = "0.48.0", default-features = false }
-polars-arrow = { version = "0.48.0", default-features = false }
-polars-ffi = { version = "0.48.0", default-features = false }
-polars-plan = { version = "0.48.0", default-features = false }
-polars-lazy = { version = "0.48.0", default-features = false }
-polars-python = { version = "0.48.0", default-features = false }
-polars-utils = { version = "0.48.0", default-features = false }
+polars = { version = "0.48.1", default-features = false }
+polars-core = { version = "0.48.1", default-features = false }
+polars-arrow = { version = "0.48.1", default-features = false }
+polars-ffi = { version = "0.48.1", default-features = false }
+polars-plan = { version = "0.48.1", default-features = false }
+polars-lazy = { version = "0.48.1", default-features = false }
+polars-python = { version = "0.48.1", default-features = false }
+polars-utils = { version = "0.48.1", default-features = false }
 
 [workspace.dependencies.arrow]
 package = "polars-arrow"
-version = "0.48.0"
+version = "0.48.1"
 path = "../polars/crates/polars-arrow"
 default-features = false
 
 # [patch.crates-io]
 # polars = { git = "https://github.com/pola-rs/polars.git" }
 # polars-core = { git = "https://github.com/pola-rs/polars.git" }
+# polars-arrow = { git = "https://github.com/pola-rs/polars.git" }
 # polars-ffi = { git = "https://github.com/pola-rs/polars.git" }
 # polars-plan = { git = "https://github.com/pola-rs/polars.git" }
 # polars-lazy = { git = "https://github.com/pola-rs/polars.git" }
+# polars-python = { git = "https://github.com/pola-rs/polars.git" }
+# polars-utils = { git = "https://github.com/pola-rs/polars.git" }

--- a/example/derive_expression/expression_lib/Cargo.toml
+++ b/example/derive_expression/expression_lib/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 num = "*"
-polars = { workspace = true, features = ["fmt", "dtype-date", "timezones", "object"], default-features = false }
+polars = { workspace = true, features = ["fmt", "dtype-date", "timezones"], default-features = false }
 polars-arrow = { workspace = true, default-features = false }
 pyo3 = { version = "0.24.2", features = ["abi3-py38"] }
 pyo3-polars = { version = "*", path = "../../../pyo3-polars", features = ["derive"] }

--- a/example/extend_polars_python_dispatch/extend_polars/Cargo.toml
+++ b/example/extend_polars_python_dispatch/extend_polars/Cargo.toml
@@ -9,7 +9,7 @@ name = "extend_polars"
 crate-type = ["cdylib"]
 
 [dependencies]
-polars = { workspace = true, features = ["fmt", "object"] }
+polars = { workspace = true, features = ["fmt"] }
 polars-core = { workspace = true }
 polars-lazy = { workspace = true }
 pyo3 = { version = "0.24.2", features = ["extension-module"] }

--- a/example/io_plugin/io_plugin/Cargo.toml
+++ b/example/io_plugin/io_plugin/Cargo.toml
@@ -9,7 +9,7 @@ name = "io_plugin"
 crate-type = ["cdylib"]
 
 [dependencies]
-polars = { workspace = true, features = ["fmt", "dtype-date", "timezones", "lazy", "object", "strings"], default-features = false }
+polars = { workspace = true, features = ["fmt", "dtype-date", "timezones", "lazy"], default-features = false }
 polars-arrow = { workspace = true, default-features = false }
 pyo3 = { version = "0.24.2", features = ["abi3-py38"] }
 pyo3-polars = { version = "*", path = "../../../pyo3-polars", features = ["derive", "lazy"] }

--- a/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1"
 
 [features]
 # Polars python is needed because all variants need to be acttivated of the DSL.
-lazy = ["polars/serde-lazy", "polars/object", "polars-plan", "polars-lazy/serde", "polars-utils", "polars-lazy/python"]
+lazy = ["polars/serde-lazy", "polars-plan", "polars-lazy/serde", "polars-utils", "polars-lazy/python"]
 derive = ["pyo3-polars-derive", "polars-plan", "polars-ffi", "serde-pickle", "serde"]
 dtype-full = ["polars/dtype-full", "dtype-decimal", "dtype-array", "dtype-struct", "dtype-categorical"]
 object = ["polars/object"]


### PR DESCRIPTION
The current head of Polars fixes the feature gate regressions. This PR reverses the feature gate changes made earlier but relies on Rust Polars 0.48.1 being released first.